### PR TITLE
Removed SVG run-length encoding by default. Issue 28

### DIFF
--- a/qrenc.c
+++ b/qrenc.c
@@ -41,6 +41,7 @@ static int size = 3;
 static int margin = -1;
 static int dpi = 72;
 static int structured = 0;
+static int rle = 0;
 static int micro = 0;
 static QRecLevel level = QR_ECLEVEL_L;
 static QRencodeMode hint = QR_MODE_8;
@@ -75,6 +76,7 @@ static const struct option options[] = {
 	{"casesensitive", no_argument      , NULL, 'c'},
 	{"ignorecase"   , no_argument      , NULL, 'i'},
 	{"8bit"         , no_argument      , NULL, '8'},
+	{"rle"		, no_argument      , NULL, 'r'},
 	{"micro"        , no_argument      , NULL, 'M'},
 	{"foreground"	, required_argument, NULL, 'f'},
 	{"background"	, required_argument, NULL, 'b'},
@@ -82,7 +84,7 @@ static const struct option options[] = {
 	{NULL, 0, NULL, 0}
 };
 
-static char *optstring = "ho:l:s:v:m:d:t:Skci8MV";
+static char *optstring = "ho:l:s:v:m:d:t:Skci8rMV";
 
 static void usage(int help, int longopt)
 {
@@ -123,6 +125,7 @@ static void usage(int help, int longopt)
 "  -i, --ignorecase\n"
 "               ignore case distinctions and use only upper-case characters.\n\n"
 "  -8, --8bit   encode entire data in 8-bit mode. -k, -c and -i will be ignored.\n\n"
+"  -r, --rle    enable run-length encoding for svg.\n\n"
 "  -M, --micro  encode in a Micro QR Code. (experimental)\n\n"
 "  --foreground=RRGGBB[AA]\n"
 "  --background=RRGGBB[AA]\n"
@@ -157,6 +160,7 @@ static void usage(int help, int longopt)
 "  -c           encode lower-case alphabet characters in 8-bit mode. (default)\n"
 "  -i           ignore case distinctions and use only upper-case characters.\n"
 "  -8           encode entire data in 8-bit mode. -k, -c and -i will be ignored.\n"
+"  -r, --rle    enable run-length encoding for svg.\n\n"
 "  -M           encode in a Micro QR Code.\n"
 "  --foreground=RRGGBB[AA]\n"
 "  --background=RRGGBB[AA]\n"
@@ -475,25 +479,35 @@ static int writeSVG( QRcode *qrcode, const char *outfile )
 	for(y=0; y<qrcode->width; y++) {
 		row = (p+(y*qrcode->width));
 
-		/* simple RLE */
-		pen = 0;
-		x0  = 0;
-		for(x=0; x<qrcode->width; x++) {
-			if( !pen ) {
-				pen = *(row+x)&0x1;
-				x0 = x;
-			} else {
-				if(!(*(row+x)&0x1)) {
-					writeSVG_writeRect(fp, x0 + margin, y + margin, x-x0, fg, fg_opacity);
-					pen = 0;
+		if( !rle ) {
+			/* no RLE */
+			for(x=0; x<qrcode->width; x++) {
+				if(*(row+x)&0x1) {
+					writeSVG_writeRect(fp,	margin + x,
+								margin + y, 1,
+								fg, fg_opacity);
 				}
 			}
-		}
-		if( pen ) {
-			writeSVG_writeRect(fp, x0 + margin, y + margin, qrcode->width - x0, fg, fg_opacity);
+		} else {
+			/* simple RLE */
+			pen = 0;
+			x0  = 0;
+			for(x=0; x<qrcode->width; x++) {
+				if( !pen ) {
+					pen = *(row+x)&0x1;
+					x0 = x;
+				} else {
+					if(!(*(row+x)&0x1)) {
+						writeSVG_writeRect(fp, x0 + margin, y + margin, x-x0, fg, fg_opacity);
+						pen = 0;
+					}
+				}
+			}
+			if( pen ) {
+				writeSVG_writeRect(fp, x0 + margin, y + margin, qrcode->width - x0, fg, fg_opacity);
+			}
 		}
 	}
-
 	/* Close QR data viewbox */
 	fputs( "\t\t</g>\n", fp );
 
@@ -1053,6 +1067,9 @@ int main(int argc, char **argv)
 				break;
 			case '8':
 				eightbit = 1;
+				break;
+			case 'r':
+				rle = 1;
 				break;
 			case 'M':
 				micro = 1;


### PR DESCRIPTION
See Issue #28

Removed run-length encoding by default in function writeSVG.
Added command line option -r -rle.
The command line is used to enable run-length encoding for svg output.
