### PR TITLE
Bugfix: Numerical result out of range. Issue #31

### DIFF
--- a/qrinput.c
+++ b/qrinput.c
@@ -984,9 +984,6 @@ static int QRinput_estimateVersion(QRinput *input)
 		prev = version;
 		bits = QRinput_estimateBitStreamSize(input, prev);
 		version = QRspec_getMinimumVersion((bits + 7) / 8, input->level);
-		if (version < 0) {
-			return -1;
-		}
 	} while (version > prev);
 
 	return version;
@@ -1165,10 +1162,7 @@ static int QRinput_convertData(QRinput *input)
 		bits = QRinput_createBitStream(input);
 		if(bits < 0) return -1;
 		ver = QRspec_getMinimumVersion((bits + 7) / 8, input->level);
-		if(ver < 0) {
-			errno = ERANGE;
-			return -1;
-		} else if(ver > QRinput_getVersion(input)) {
+		if(ver > QRinput_getVersion(input)) {
 			QRinput_setVersion(input, ver);
 		} else {
 			break;

--- a/qrspec.c
+++ b/qrspec.c
@@ -113,13 +113,12 @@ int QRspec_getMinimumVersion(int size, QRecLevel level)
 	int i;
 	int words;
 
-	for(i=1; i<= QRSPEC_VERSION_MAX+1; i++) {
+	for(i=1; i<= QRSPEC_VERSION_MAX; i++) {
 		words  = qrspecCapacity[i].words - qrspecCapacity[i].ec[level];
-		if(i >  QRSPEC_VERSION_MAX) return QRSPEC_VERSION_MAX;
 		if(words >= size) return i;
 	}
 
-	return -1;
+	return QRSPEC_VERSION_MAX;
 }
 
 int QRspec_getWidth(int version)


### PR DESCRIPTION
To meet the specification at QR-Code version 40 (maximum character).
But I didn't do much testing on this.
