### PR TITLE
Check return value of BitStream_expand

### DIFF
--- a/bitstream.c
+++ b/bitstream.c
@@ -105,6 +105,8 @@ static void BitStream_writeBytes(unsigned char *dest, int size, unsigned char *d
 
 int BitStream_append(BitStream *bstream, BitStream *arg)
 {
+	int ret;
+
 	if(arg == NULL) {
 		return -1;
 	}
@@ -113,7 +115,8 @@ int BitStream_append(BitStream *bstream, BitStream *arg)
 	}
 
 	while(bstream->length + arg->length > bstream->datasize) {
-		BitStream_expand(bstream);
+		ret = BitStream_expand(bstream);
+		if(ret < 0) return ret;
 	}
 
 	memcpy(bstream->data + bstream->length, arg->data, arg->length);


### PR DESCRIPTION
All other callsites of BitStream_expand check for the return value, so do it here as well, since the realloc() could fail and BitStream_expand would then return -1 to signal this.
