### PR TITLE
Add support for manual mask specification

### DIFF
--- a/mask.c
+++ b/mask.c
@@ -140,7 +140,6 @@ static int Mask_mask7(int width, const unsigned char *s, unsigned char *d)
 	MASKMAKER((((x*y)%3)+((x+y)&1))&1)
 }
 
-#define maskNum (8)
 typedef int MaskMaker(int, const unsigned char *, unsigned char *);
 static MaskMaker *maskMakers[maskNum] = {
 	Mask_mask0, Mask_mask1, Mask_mask2, Mask_mask3,

--- a/mask.h
+++ b/mask.h
@@ -22,6 +22,8 @@
 #ifndef __MASK_H__
 #define __MASK_H__
 
+#define maskNum (8)
+
 extern unsigned char *Mask_makeMask(int width, unsigned char *frame, int mask, QRecLevel level);
 extern unsigned char *Mask_mask(int width, unsigned char *frame, QRecLevel level);
 

--- a/qrenc.c
+++ b/qrenc.c
@@ -115,7 +115,7 @@ static void usage(int help, int longopt, int status)
 "               specify the version of the symbol. (default=auto)\n\n"
 "  -m NUMBER, --margin=NUMBER\n"
 "               specify the width of the margins. (default=4 (2 for Micro)))\n\n"
-"  -M NUMBER, --mask=NUMBER\n"
+"  -a NUMBER, --mask=NUMBER\n"
 "               specify the mask. (default=-1 (auto-detected)))\n\n"
 "  -d NUMBER, --dpi=NUMBER\n"
 "               specify the DPI of the generated PNG. (default=72)\n\n"

--- a/qrencode.c
+++ b/qrencode.c
@@ -611,16 +611,16 @@ EXIT:
 	return qrcode;
 }
 
-QRcode *QRcode_encodeInput(QRinput *input)
+QRcode *QRcode_encodeInput(QRinput *input, int mask)
 {
 	if(input->mqr) {
-		return QRcode_encodeMaskMQR(input, -1);
+		return QRcode_encodeMaskMQR(input, mask);
 	} else {
-		return QRcode_encodeMask(input, -1);
+		return QRcode_encodeMask(input, mask);
 	}
 }
 
-static QRcode *QRcode_encodeStringReal(const char *string, int version, QRecLevel level, int mqr, QRencodeMode hint, int casesensitive)
+static QRcode *QRcode_encodeStringReal(const char *string, int version, QRecLevel level, int mqr, QRencodeMode hint, int casesensitive, int mask)
 {
 	QRinput *input;
 	QRcode *code;
@@ -647,23 +647,23 @@ static QRcode *QRcode_encodeStringReal(const char *string, int version, QRecLeve
 		QRinput_free(input);
 		return NULL;
 	}
-	code = QRcode_encodeInput(input);
+	code = QRcode_encodeInput(input, mask);
 	QRinput_free(input);
 
 	return code;
 }
 
-QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive)
+QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive, int mask)
 {
-	return QRcode_encodeStringReal(string, version, level, 0, hint, casesensitive);
+	return QRcode_encodeStringReal(string, version, level, 0, hint, casesensitive, mask);
 }
 
-QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive)
+QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive, int mask)
 {
-	return QRcode_encodeStringReal(string, version, level, 1, hint, casesensitive);
+	return QRcode_encodeStringReal(string, version, level, 1, hint, casesensitive, mask);
 }
 
-static QRcode *QRcode_encodeDataReal(const unsigned char *data, int length, int version, QRecLevel level, int mqr)
+static QRcode *QRcode_encodeDataReal(const unsigned char *data, int length, int version, QRecLevel level, int mqr, int mask)
 {
 	QRinput *input;
 	QRcode *code;
@@ -686,38 +686,38 @@ static QRcode *QRcode_encodeDataReal(const unsigned char *data, int length, int 
 		QRinput_free(input);
 		return NULL;
 	}
-	code = QRcode_encodeInput(input);
+	code = QRcode_encodeInput(input, mask);
 	QRinput_free(input);
 
 	return code;
 }
 
-QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level)
+QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level, int mask)
 {
-	return QRcode_encodeDataReal(data, size, version, level, 0);
+	return QRcode_encodeDataReal(data, size, version, level, 0, mask);
 }
 
-QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level)
+QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level, int mask)
 {
 	if(string == NULL) {
 		errno = EINVAL;
 		return NULL;
 	}
-	return QRcode_encodeDataReal((unsigned char *)string, strlen(string), version, level, 0);
+	return QRcode_encodeDataReal((unsigned char *)string, strlen(string), version, level, 0, mask);
 }
 
-QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level)
+QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level, int mask)
 {
-	return QRcode_encodeDataReal(data, size, version, level, 1);
+	return QRcode_encodeDataReal(data, size, version, level, 1, mask);
 }
 
-QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level)
+QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level, int mask)
 {
 	if(string == NULL) {
 		errno = EINVAL;
 		return NULL;
 	}
-	return QRcode_encodeDataReal((unsigned char *)string, strlen(string), version, level, 1);
+	return QRcode_encodeDataReal((unsigned char *)string, strlen(string), version, level, 1, mask);
 }
 
 
@@ -803,7 +803,7 @@ QRcode_List *QRcode_encodeInputStructured(QRinput_Struct *s)
 			tail->next = entry;
 			tail = tail->next;
 		}
-		tail->code = QRcode_encodeInput(list->input);
+		tail->code = QRcode_encodeInput(list->input, -1);
 		if(tail->code == NULL) {
 			goto ABORT;
 		}

--- a/qrencode.h
+++ b/qrencode.h
@@ -391,6 +391,7 @@ typedef struct _QRcode_List {
  * Create a symbol from the input data.
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  * @param input input data.
+ * @param mask mask constant to use, or -1 for auto-select
  * @return an instance of QRcode class. The version of the result QRcode may
  *         be larger than the designated version. On error, NULL is returned,
  *         and errno is set to indicate the error. See Exceptions for the
@@ -398,7 +399,7 @@ typedef struct _QRcode_List {
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory for input objects.
  */
-extern QRcode *QRcode_encodeInput(QRinput *input);
+extern QRcode *QRcode_encodeInput(QRinput *input, int mask);
 
 /**
  * Create a symbol from the string. The library automatically parses the input
@@ -415,6 +416,7 @@ extern QRcode *QRcode_encodeInput(QRinput *input);
  *             characters will be encoded as is. If you want to embed UTF-8
  *             string, choose this. Other mode will cause EINVAL error.
  * @param casesensitive case-sensitive(1) or not(0).
+ * @param mask mask constant to use, or -1 for auto-select
  * @return an instance of QRcode class. The version of the result QRcode may
  *         be larger than the designated version. On error, NULL is returned,
  *         and errno is set to indicate the error. See Exceptions for the
@@ -423,25 +425,25 @@ extern QRcode *QRcode_encodeInput(QRinput *input);
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw ERANGE input data is too large.
  */
-extern QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
+extern QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive, int mask);
 
 /**
  * Same to QRcode_encodeString(), but encode whole data in 8-bit mode.
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level);
+extern QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level, int mask);
 
 /**
  * Micro QR Code version of QRcode_encodeString().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
+extern QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive, int mask);
 
 /**
  * Micro QR Code version of QRcode_encodeString8bit().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level);
+extern QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level, int mask);
 
 /**
  * Encode byte stream (may include '\0') in 8-bit mode.
@@ -451,17 +453,18 @@ extern QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecL
  * @param version version of the symbol. If 0, the library chooses the minimum
  *                version for the given input data.
  * @param level error correction level.
+ * @param mask mask constant to use, or -1 for auto-select
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw ERANGE input data is too large.
  */
-extern QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level);
+extern QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level, int mask);
 
 /**
  * Micro QR Code version of QRcode_encodeData().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level);
+extern QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level, int mask);
 
 /**
  * Free the instance of QRcode class.


### PR DESCRIPTION
Add support for a manual specification of the mask pattern in the command-line qrencode tool (choosing automatically as usual by default).
