### PR TITLE
Clean up warnings.

### DIFF
--- a/mask.c
+++ b/mask.c
@@ -339,7 +339,6 @@ unsigned char *Mask_mask(int width, unsigned char *frame, QRecLevel level)
 
 	for(i=0; i<maskNum; i++) {
 //		n1 = n2 = n3 = n4 = 0;
-		demerit = 0;
 		blacks = maskMakers[i](width, frame, mask);
 		blacks += Mask_writeFormatInformation(width, mask, i, level);
 		bratio = (200 * blacks + w2) / w2 / 2; /* (int)(100*blacks/w2+0.5) */

--- a/mmask.c
+++ b/mmask.c
@@ -160,7 +160,6 @@ unsigned char *MMask_mask(int version, unsigned char *frame, QRecLevel level)
 	bestMask = NULL;
 
 	for(i=0; i<maskNum; i++) {
-		score = 0;
 		maskMakers[i](width, frame, mask);
 		MMask_writeFormatInformation(version, width, mask, i, level);
 		score = MMask_evaluateSymbol(width, mask);

--- a/qrinput.c
+++ b/qrinput.c
@@ -1537,7 +1537,7 @@ QRinput_Struct *QRinput_splitQRinputToStruct(QRinput *input)
 				list = next;
 			} else {
 				/* Current entry will go to the next input. */
-				prev->next = NULL;
+				if (prev) prev->next = NULL;
 				p->head = list;
 				p->tail = input->tail;
 				input->tail = prev;


### PR DESCRIPTION
This cleans up a few warnings that the Clang static analyser picks up.  The zero assignments are never used, and prev->next is flagged as potentially dereferencing a NULL pointer.
