### PR TITLE
Typo in qrencode(1) manpage

### DIFF
--- a/qrencode.1.in
+++ b/qrencode.1.in
@@ -27,7 +27,7 @@ write image to FILENAME. If '\-' is specified, the result will be output to stan
 specify the size of dot (pixel). (default=3)
 .TP
 .B \-l {LMQH}, \-\-level={LMQH}
-specify error collectin level from L (lowest) to H (highest). (default=L)
+specify error correction level from L (lowest) to H (highest). (default=L)
 .TP
 .B \-v NUMBER, \-\-symversion=NUMBER
 specify the version of the symbol. See SYMBOL VERSIONS for more information. (default=auto)


### PR DESCRIPTION
Fixed a typo in the qrencode(1) manpage.

'collectin' --> 'correction'