### PR TITLE
Update split.c

### DIFF
--- a/split.c
+++ b/split.c
@@ -44,9 +44,9 @@
 char *strdup(const char *s)
 {
 	size_t len = strlen(s) + 1;
-	void *new = malloc(len);
-	if(new == NULL) return NULL;
-	return (char *)memcpy(new, s, len);
+	void *newstring = malloc(len);
+	if(newstring == NULL) return NULL;
+	return (char *)memcpy(newstring, s, len);
 }
 #endif
 


### PR DESCRIPTION
new is a reserved Keyword in C++ and should not be used as variable name. Therefore i propose the change from new to newstring. I allready send u an email with a patch but then i found the github repository. 