### PR TITLE
spelling mistake

### DIFF
--- a/qrspec.h
+++ b/qrspec.h
@@ -76,7 +76,7 @@ extern int QRspec_getRemainder(int version);
  *****************************************************************************/
 
 /**
- * Return the size of lenght indicator for the mode and version.
+ * Return the size of length indicator for the mode and version.
  * @param mode encode mode
  * @param version vesion of the symbol
  * @return the size of the appropriate length indicator (bits).


### PR DESCRIPTION
The line of comment have a spelling mistake.