### PR TITLE
Fix build on windows with Visual Studio

### DIFF
--- a/qrencode.h
+++ b/qrencode.h
@@ -555,7 +555,11 @@ extern char *QRcode_APIVersionString(void);
 /**
  * @deprecated
  */
+#ifndef _MSC_VER
 extern void QRcode_clearCache(void) __attribute__ ((deprecated));
+#else
+extern void QRcode_clearCache(void);
+#endif
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Visual Studio does not support GCC attributes.