### PR TITLE
tests: Add missing test_basic.sh to EXTRA_DIST

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,7 @@ if HAVE_LIBPTHREAD
 noinst_PROGRAMS += pthread_qrencode
 endif
 
-EXTRA_DIST = test_all.sh test_configure.sh frame URI_testset.inc CMakeLists.txt
+EXTRA_DIST = test_all.sh test_basic.sh test_configure.sh frame URI_testset.inc CMakeLists.txt
 
 libdecoder_a_SOURCES = decoder.c decoder.h datachunk.c datachunk.h rsecc_decoder.c rsecc_decoder.h
 


### PR DESCRIPTION
Add test_basic.sh to EXTRA_DIST to ensure that it's present in release
tarballs.  It's missing in 4.0.1 release which breaks test_all.sh.