### PR TITLE
cmake: Use GNUInstallDirs for configurable install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,11 @@ set(VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION
 configure_file(qrencode.1.in qrencode.1 @ONLY)
 configure_file(libqrencode.pc.in libqrencode.pc @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qrencode.1 DESTINATION share/man/man1)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libqrencode.pc DESTINATION lib/pkgconfig)
-install(FILES qrencode.h DESTINATION include)
-install(TARGETS qrencode DESTINATION lib)
+include(GNUInstallDirs)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qrencode.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libqrencode.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES qrencode.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(TARGETS qrencode DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ## Build utility tools
 if(WITH_TOOLS)
@@ -136,7 +137,7 @@ if(WITH_TOOLS)
         target_link_libraries(qrenc ${GETOPT_LIBRARIES})
     endif(MSVC)
 
-    install(TARGETS qrenc DESTINATION bin)
+    install(TARGETS qrenc DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if(WITH_TESTS)


### PR DESCRIPTION
Use CMake GNUInstallDirs module to provide variables for configurable
install directories.  This is necessary to install libqrencode on amd64
systems where libraries belong in /usr/lib64 rather than /usr/lib.
While at it, make all install directories configurable for user's
convenience.