### PR TITLE
Fix running test_qrspec when building out-of-source

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ if(TARGET ICONV::ICONV)
 
     MAKE_TEST(test_qrinput decoder)
     MAKE_TEST(test_qrspec decoder)
+    target_compile_definitions(test_qrspec PRIVATE -DSRCDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
     MAKE_TEST(test_mqrspec decoder)
     MAKE_TEST(test_qrencode decoder)
     MAKE_TEST(test_split_urls decoder)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,6 +37,7 @@ test_estimatebit_SOURCES = test_estimatebit.c common.c
 test_estimatebit_LDADD = ../libqrencode.la
 
 test_qrspec_SOURCES = test_qrspec.c common.c
+test_qrspec_CPPFLAGS = -DSRCDIR=\"$(srcdir)/\"
 test_qrspec_LDADD = $(DECODER_LIBS) ../libqrencode.la
 
 test_mqrspec_SOURCES = test_mqrspec.c common.c

--- a/tests/test_qrspec.c
+++ b/tests/test_qrspec.c
@@ -5,6 +5,10 @@
 #include "../qrencode_inner.h"
 #include "decoder.h"
 
+#ifndef SRCDIR
+#	define SRCDIR
+#endif
+
 static void print_eccTable(void)
 {
 	int i, j;
@@ -130,9 +134,9 @@ static void test_newframe(void)
 	int version;
 
 	testStart("Checking newly created frame.");
-	fp = fopen("frame", "rb");
+	fp = fopen(SRCDIR "frame", "rb");
 	if(fp == NULL) {
-		perror("Failed to open \"frame\":");
+		perror("Failed to open \"" SRCDIR "frame\":");
 		abort();
 	}
 	for(i=1; i<=QRSPEC_VERSION_MAX; i++) {


### PR DESCRIPTION
It is a common practice for CMake builds (and less common but still
valid for autotools) to build out-of-source, that is use a separate
directory for built executables than for sources.  However, when that is
used, test_qrspec is unable to find "frame" and crashes.  Fix it by
passing the source directory as compile-time definition, and therefore
making test_qrspec use the correct path.