### PR TITLE
Change CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR in CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(BUILD_TESTING)
     message(DEPRECATION "use WITH_TESTS option instead BUILD_TESTING")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads)


### PR DESCRIPTION
When I use your project as a subdirectory, CMAKE_SOURCE_DIR is a path to my project and not yours.
CMAKE_CURRENT_SOURCE_DIR is the path of your project.