### PR TITLE
Fix invalid XPM output. (trivial patch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,5 +202,5 @@ Copyright (C) 2002, 2003, 2004, 2006 Phil Karn, KA9Q
   David Binderman, @ralgozino, Sean McMurray, Vlad Bespalov (@win32asm),
   Antenore Gatta, Yoshimichi Inoue, Sunil Maganally, Norman Gray,
   Danomi Manchego, @minus7, Ian Sweet, @qianchenglenger, Ronald Michaels,
-  Yuji Ueno, Jakub Wilk, @KangLin, @c-273, @thebunnyrules
+  Yuji Ueno, Jakub Wilk, @KangLin, @c-273, @thebunnyrules, @dlitz
                         - bug report / suggestion / typo fixes

--- a/qrenc.c
+++ b/qrenc.c
@@ -718,7 +718,7 @@ static int writeXPM(const QRcode *qrcode, const char *outfile)
 	}
 
 	for (y = 0; y < realmargin; y++) {
-		fprintf(fp, "\"%s\"%s\n", row, y < (size - 1) ? "," : "};");
+		fprintf(fp, "\"%s\"%s\n", row, y < (realmargin - 1) ? "," : "};");
 	}
 
 	free(row);


### PR DESCRIPTION
XPM is supposed to be a valid C syntax[1], but the output of
qrencode doesn't parse:

    $ qrencode -M -v1 -t XPM 12345 > x.c
    $ cc -c x.c
    x.c:51:1: error: expected identifier or ‘(’ before string constant
     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    x.c:52:1: error: expected identifier or ‘(’ before string constant
     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    x.c:53:1: error: expected identifier or ‘(’ before string constant
     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Looking at the bottom of the output, we can see that the trailing brace
and semicolon are repeated:

    /* XPM */
    static const char *const qrcode_xpm[] = {
    /* width height ncolors chars_per_pixel */
    "45 45 2 1",
    /* colors */
    "F c #000000",
    "B c #ffffff",
    /* pixels */
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
                // snipped 35 lines //
    "BBBBBBFFFFFFFFFBBBFFFBBBFFFFFFFFFFFFFFFBBBBBB",
    "BBBBBBFFFFFFFFFBBBFFFBBBFFFFFFFFFFFFFFFBBBBBB",
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"};

[1] https://www.x.org/docs/XPM/xpm.pdf