### PR TITLE
Fix output of FNC1 in first position needed for GS1

### DIFF
--- a/qrinput.c
+++ b/qrinput.c
@@ -729,6 +729,16 @@ static int QRinput_encodeModeStructure(QRinput_List *entry, BitStream *bstream, 
  * FNC1
  *****************************************************************************/
 
+static int QRinput_encodeModeFNC1First(BitStream *bstream)
+{
+	int ret;
+
+	ret = BitStream_appendNum(bstream, 4, QRSPEC_MODEID_FNC1FIRST);
+	if(ret < 0) return -1;
+
+	return 0;
+}
+
 static int QRinput_checkModeFNC1Second(int size)
 {
 	if(size != 1) return -1;
@@ -818,7 +828,7 @@ static int QRinput_encodeModeECI(QRinput_List *entry, BitStream *bstream)
 
 int QRinput_check(QRencodeMode mode, int size, const unsigned char *data)
 {
-	if((mode == QR_MODE_FNC1FIRST && size < 0) || size <= 0) return -1;
+	if(mode != QR_MODE_FNC1FIRST && size <= 0) return -1;
 
 	switch(mode) {
 		case QR_MODE_NUM:
@@ -1045,6 +1055,9 @@ static int QRinput_encodeBitStream(QRinput_List *entry, BitStream *bstream, int 
 				break;
 			case QR_MODE_ECI:
 				ret = QRinput_encodeModeECI(entry, bstream);
+				break;
+			case QR_MODE_FNC1FIRST:
+				ret = QRinput_encodeModeFNC1First(bstream);
 				break;
 			case QR_MODE_FNC1SECOND:
 				ret = QRinput_encodeModeFNC1Second(entry, bstream);


### PR DESCRIPTION
It appears that this functionality was not fully implemented. Thus, code generation always failed when trying to use QRinput_setFNC1First().

Signed-off-by: Rüdiger Ihle <r.ihle@s-t.de>