### PR TITLE
Set LDFLAGS for cygwin as for mingw, to be able to build dll.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,6 @@ qrencode_LDADD = libqrencode.la $(png_LIBS)
 man1_MANS = qrencode.1
 endif
 
-if MINGW
+if CYGWIN_OR_MINGW
 libqrencode_la_LDFLAGS += -no-undefined -avoid-version -Wl,--nxcompat -Wl,--dynamicbase
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -37,10 +37,10 @@ AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG
 
 case "${target}" in
-*-*-mingw*)
-	mingw=yes
+*-*-cygwin*|*-*-mingw*)
+	cygwin_or_mingw=yes
 esac
-AM_CONDITIONAL(MINGW, [test "x$mingw" = "xyes" ])
+AM_CONDITIONAL(CYGWIN_OR_MINGW, [test "x$cygwin_or_mingw" = "xyes" ])
 
 AC_CONFIG_FILES([Makefile libqrencode.pc tests/Makefile qrencode.1])
 


### PR DESCRIPTION
Cygwin build failed due to libtool expecting `-no-undefined`. Fixed by setting LDFLAGS as for MinGW. I think this is appropriate enough.