### PR TITLE
Use separate flags for MinGW and Cygwin, as `-avoid-version` not not …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,9 @@ qrencode_LDADD = libqrencode.la $(png_LIBS)
 man1_MANS = qrencode.1
 endif
 
-if CYGWIN_OR_MINGW
+if MINGW
 libqrencode_la_LDFLAGS += -no-undefined -avoid-version -Wl,--nxcompat -Wl,--dynamicbase
+endif
+if CYGWIN
+libqrencode_la_LDFLAGS += -no-undefined
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -37,10 +37,13 @@ AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG
 
 case "${target}" in
-*-*-cygwin*|*-*-mingw*)
-	cygwin_or_mingw=yes
+*-*-cygwin*)
+	cygwin=yes;;
+*-*-mingw*)
+	mingw=yes;;
 esac
-AM_CONDITIONAL(CYGWIN_OR_MINGW, [test "x$cygwin_or_mingw" = "xyes" ])
+AM_CONDITIONAL(MINGW, [test "x$mingw" = "xyes" ])
+AM_CONDITIONAL(CYGWIN, [test "x$cygwin" = "xyes" ])
 
 AC_CONFIG_FILES([Makefile libqrencode.pc tests/Makefile qrencode.1])
 


### PR DESCRIPTION
…desired for Cygwin and `-Wl,--nxcompat -Wl,--dynamicbase` may cause trouble in conjuction with other DLLs as discussed in PR #175.