### PR TITLE
Introduce option to remove SVG background completely

### DIFF
--- a/qrenc.c
+++ b/qrenc.c
@@ -588,11 +588,13 @@ static int writeSVG(const QRcode *qrcode, const char *outfile)
 	fputs("\t<g id=\"QRcode\">\n", fp);
 
 	/* Make solid background */
-	if(bg_color[3] != 255) {
-		fprintf(fp, "\t\t<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%s\" fill-opacity=\"%f\"/>\n", symwidth, symwidth, bg, bg_opacity);
-	} else {
-		fprintf(fp, "\t\t<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%s\"/>\n", symwidth, symwidth, bg);
-	}
+  if(bg_color[3] > 0) {
+    if(bg_color[3] != 255) {
+      fprintf(fp, "\t\t<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%s\" fill-opacity=\"%f\"/>\n", symwidth, symwidth, bg, bg_opacity);
+    } else {
+      fprintf(fp, "\t\t<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%s\"/>\n", symwidth, symwidth, bg);
+    }
+  }
 
 	if(svg_path) {
 		if(fg_color[3] != 255) {

--- a/qrenc.c
+++ b/qrenc.c
@@ -44,6 +44,7 @@ static int dpi = 72;
 static int structured = 0;
 static int rle = 0;
 static int svg_path = 0;
+static int svg_no_background = 0;
 static int micro = 0;
 static int inline_svg = 0;
 static int strict_versioning = 0;
@@ -91,6 +92,7 @@ static const struct option options[] = {
 	{"micro"         , no_argument      , NULL, 'M'},
 	{"rle"           , no_argument      , &rle,   1},
 	{"svg-path"      , no_argument      , &svg_path, 1},
+	{"svg-no-background", no_argument   , &svg_no_background, 1},
 	{"inline"        , no_argument      , &inline_svg, 1},
 	{"strict-version", no_argument      , &strict_versioning, 1},
 	{"foreground"    , required_argument, NULL, 'f'},
@@ -155,6 +157,8 @@ static void usage(int help, int longopt, int status)
 "               specify foreground/background color in hexadecimal notation.\n"
 "               6-digit (RGB) or 8-digit (RGBA) form are supported.\n"
 "               Color output support available only in PNG, EPS and SVG.\n\n"
+"      --svg-no-background\n"
+"               don't add a background for SVG output.\n\n"
 "      --strict-version\n"
 "               disable automatic version number adjustment. If the input data is\n"
 "               too large for the specified version, the program exits with the\n"
@@ -588,7 +592,7 @@ static int writeSVG(const QRcode *qrcode, const char *outfile)
 	fputs("\t<g id=\"QRcode\">\n", fp);
 
 	/* Make solid background */
-  if(bg_color[3] > 0) {
+  if(!svg_no_background) { 
     if(bg_color[3] != 255) {
       fprintf(fp, "\t\t<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%s\" fill-opacity=\"%f\"/>\n", symwidth, symwidth, bg, bg_opacity);
     } else {

--- a/qrencode.1.in
+++ b/qrencode.1.in
@@ -73,6 +73,9 @@ enable run-length encoding for SVG.
 .B \-\-svg-path
 use single path to draw modules for SVG.
 .TP
+.B \-\-svg-no-background
+don't add a background for SVG output.
+.TP
 .B \-\-inline
 only useful for SVG output, generates an SVG without the XML tag.
 .TP


### PR DESCRIPTION
This Merge Request introduces an option `--svg-no-background` which causes the SVG background rectangle to be dropped. This can help when importing the resulting SVG into other software (like OpenSCAD) where the (invisible) background is then still recognised as an object.