### PR TITLE
Fix XPM termination with margin other than 1 / Solves issue #193 and #188

### DIFF
--- a/qrenc.c
+++ b/qrenc.c
@@ -724,8 +724,10 @@ static int writeXPM(const QRcode *qrcode, const char *outfile)
 	}
 
 	for (y = 0; y < realmargin; y++) {
-		fprintf(fp, "\"%s\"%s\n", row, y < (size - 1) ? "," : "};");
+		fprintf(fp, "\"%s\",\n", row);
 	}
+
+    fputs("};\n", fp);
 
 	free(row);
 	fclose(fp);


### PR DESCRIPTION
process bottom margin like top margine by adding empty row at the end of QR data
and always terminate the block even if there is no magin.

Note : the last ',' at the end of the table seems to be valid with every C compiler or every image processor i checked.

Solves issue #193 and #188
