### PR TITLE
Fix the strncat Wformat-overflow warning when using gcc 11.3.0

### DIFF
--- a/qrenc.c
+++ b/qrenc.c
@@ -794,7 +794,7 @@ static int writeANSI(const QRcode *qrcode, const char *outfile)
 		memset(buffer, 0, (size_t)buffer_s);
 		strncpy(buffer, white, (size_t)white_s);
 		for(x = 0; x < margin; x++ ){
-			strncat(buffer, "  ", 2);
+			strcat(buffer, "  ");
 		}
 		last = 0;
 
@@ -808,16 +808,16 @@ static int writeANSI(const QRcode *qrcode, const char *outfile)
 				strncat(buffer, white, (size_t)white_s);
 				last = 0;
 			}
-			strncat(buffer, "  ", 2);
+			strcat(buffer, "  ");
 		}
 
 		if( last != 0 ){
 			strncat(buffer, white, (size_t)white_s);
 		}
 		for(x = 0; x < margin; x++ ){
-			strncat(buffer, "  ", 2);
+			strcat(buffer, "  ");
 		}
-		strncat(buffer, "\033[0m\n", 5);
+		strcat(buffer, "\033[0m\n");
 		fputs(buffer, fp);
 	}
 


### PR DESCRIPTION
Replacing strncpy with strcpy fixes this warnings
References: https://stackoverflow.com/questions/53408543/strncat-wformat-overflow-warning-when-using-gcc-8-2-1

qrenc.c:797:25: warning: ‘strncat’ specified bound 2 equals source length [-Wstringop-overflow=]
  797 |                         strncat(buffer, "  ", 2);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
qrenc.c:811:25: warning: ‘strncat’ specified bound 2 equals source length [-Wstringop-overflow=]
  811 |                         strncat(buffer, "  ", 2);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
qrenc.c:818:25: warning: ‘strncat’ specified bound 2 equals source length [-Wstringop-overflow=]
  818 |                         strncat(buffer, "  ", 2);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
qrenc.c:820:17: warning: ‘strncat’ specified bound 5 equals source length [-Wstringop-overflow=]
  820 |                 strncat(buffer, "\033[0m\n", 5);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~