### PR TITLE
Specify `__declspec(dll{ex,im}port)` where appropriate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ AC_DEFINE_UNQUOTED([MAJOR_VERSION], [$MAJOR_VERSION], [Major version number])
 AC_DEFINE_UNQUOTED([MINOR_VERSION], [$MINOR_VERSION], [Minor version number])
 AC_DEFINE_UNQUOTED([MICRO_VERSION], [$MICRO_VERSION], [Micro version number])
 
+AC_DEFINE([BUILDING_QRENCODE], [], [Specify we are currently building QRencode])
+
 AC_CONFIG_SRCDIR([qrencode.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR(use)

--- a/qrencode.h
+++ b/qrencode.h
@@ -103,6 +103,16 @@
 extern "C" {
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(BUILDING_QRENCODE)
+#define QRENCODE_EXTERN __declspec(dllexport)
+#else
+#define QRENCODE_EXTERN __declspec(dllimport)
+#endif
+#else
+#define QRENCODE_EXTERN extern
+#endif
+
 /**
  * Encoding mode.
  */
@@ -158,7 +168,7 @@ typedef struct _QRinput QRinput;
  *         is set to indicate the error.
  * @throw ENOMEM unable to allocate memory.
  */
-extern QRinput *QRinput_new(void);
+QRENCODE_EXTERN QRinput *QRinput_new(void);
 
 /**
  * Instantiate an input data object.
@@ -169,7 +179,7 @@ extern QRinput *QRinput_new(void);
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw EINVAL invalid arguments.
  */
-extern QRinput *QRinput_new2(int version, QRecLevel level);
+QRENCODE_EXTERN QRinput *QRinput_new2(int version, QRecLevel level);
 
 /**
  * Instantiate an input data object. Object's Micro QR Code flag is set.
@@ -181,7 +191,7 @@ extern QRinput *QRinput_new2(int version, QRecLevel level);
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw EINVAL invalid arguments.
  */
-extern QRinput *QRinput_newMQR(int version, QRecLevel level);
+QRENCODE_EXTERN QRinput *QRinput_newMQR(int version, QRecLevel level);
 
 /**
  * Append data to an input object.
@@ -197,7 +207,7 @@ extern QRinput *QRinput_newMQR(int version, QRecLevel level);
  * @throw EINVAL input data is invalid.
  *
  */
-extern int QRinput_append(QRinput *input, QRencodeMode mode, int size, const unsigned char *data);
+QRENCODE_EXTERN int QRinput_append(QRinput *input, QRencodeMode mode, int size, const unsigned char *data);
 
 /**
  * Append ECI header.
@@ -210,14 +220,14 @@ extern int QRinput_append(QRinput *input, QRencodeMode mode, int size, const uns
  * @throw EINVAL input data is invalid.
  *
  */
-extern int QRinput_appendECIheader(QRinput *input, unsigned int ecinum);
+QRENCODE_EXTERN int QRinput_appendECIheader(QRinput *input, unsigned int ecinum);
 
 /**
  * Get current version.
  * @param input input object.
  * @return current version.
  */
-extern int QRinput_getVersion(QRinput *input);
+QRENCODE_EXTERN int QRinput_getVersion(QRinput *input);
 
 /**
  * Set version of the QR code that is to be encoded.
@@ -227,14 +237,14 @@ extern int QRinput_getVersion(QRinput *input);
  * @retval 0 success.
  * @retval -1 invalid argument.
  */
-extern int QRinput_setVersion(QRinput *input, int version);
+QRENCODE_EXTERN int QRinput_setVersion(QRinput *input, int version);
 
 /**
  * Get current error correction level.
  * @param input input object.
  * @return Current error correcntion level.
  */
-extern QRecLevel QRinput_getErrorCorrectionLevel(QRinput *input);
+QRENCODE_EXTERN QRecLevel QRinput_getErrorCorrectionLevel(QRinput *input);
 
 /**
  * Set error correction level of the QR code that is to be encoded.
@@ -244,7 +254,7 @@ extern QRecLevel QRinput_getErrorCorrectionLevel(QRinput *input);
  * @retval 0 success.
  * @retval -1 invalid argument.
  */
-extern int QRinput_setErrorCorrectionLevel(QRinput *input, QRecLevel level);
+QRENCODE_EXTERN int QRinput_setErrorCorrectionLevel(QRinput *input, QRecLevel level);
 
 /**
  * Set version and error correction level of the QR code at once.
@@ -255,14 +265,14 @@ extern int QRinput_setErrorCorrectionLevel(QRinput *input, QRecLevel level);
  * @retval 0 success.
  * @retval -1 invalid argument.
  */
-extern int QRinput_setVersionAndErrorCorrectionLevel(QRinput *input, int version, QRecLevel level);
+QRENCODE_EXTERN int QRinput_setVersionAndErrorCorrectionLevel(QRinput *input, int version, QRecLevel level);
 
 /**
  * Free the input object.
  * All of data chunks in the input object are freed too.
  * @param input input object.
  */
-extern void QRinput_free(QRinput *input);
+QRENCODE_EXTERN void QRinput_free(QRinput *input);
 
 /**
  * Validate the input data.
@@ -272,7 +282,7 @@ extern void QRinput_free(QRinput *input);
  * @retval 0 success.
  * @retval -1 invalid arguments.
  */
-extern int QRinput_check(QRencodeMode mode, int size, const unsigned char *data);
+QRENCODE_EXTERN int QRinput_check(QRencodeMode mode, int size, const unsigned char *data);
 
 /**
  * Set of QRinput for structured symbols.
@@ -285,14 +295,14 @@ typedef struct _QRinput_Struct QRinput_Struct;
  *         is set to indicate the error.
  * @throw ENOMEM unable to allocate memory.
  */
-extern QRinput_Struct *QRinput_Struct_new(void);
+QRENCODE_EXTERN QRinput_Struct *QRinput_Struct_new(void);
 
 /**
  * Set parity of structured symbols.
  * @param s structured input object.
  * @param parity parity of s.
  */
-extern void QRinput_Struct_setParity(QRinput_Struct *s, unsigned char parity);
+QRENCODE_EXTERN void QRinput_Struct_setParity(QRinput_Struct *s, unsigned char parity);
 
 /**
  * Append a QRinput object to the set. QRinput created by QRinput_newMQR()
@@ -305,13 +315,13 @@ extern void QRinput_Struct_setParity(QRinput_Struct *s, unsigned char parity);
  * @throw ENOMEM unable to allocate memory.
  * @throw EINVAL invalid arguments.
  */
-extern int QRinput_Struct_appendInput(QRinput_Struct *s, QRinput *input);
+QRENCODE_EXTERN int QRinput_Struct_appendInput(QRinput_Struct *s, QRinput *input);
 
 /**
  * Free all of QRinput in the set.
  * @param s a structured input object.
  */
-extern void QRinput_Struct_free(QRinput_Struct *s);
+QRENCODE_EXTERN void QRinput_Struct_free(QRinput_Struct *s);
 
 /**
  * Split a QRinput to QRinput_Struct. It calculates a parity, set it, then
@@ -325,7 +335,7 @@ extern void QRinput_Struct_free(QRinput_Struct *s);
  * @throw EINVAL invalid input data.
  * @throw ENOMEM unable to allocate memory.
  */
-extern QRinput_Struct *QRinput_splitQRinputToStruct(QRinput *input);
+QRENCODE_EXTERN QRinput_Struct *QRinput_splitQRinputToStruct(QRinput *input);
 
 /**
  * Insert structured-append headers to the input structure. It calculates
@@ -337,17 +347,17 @@ extern QRinput_Struct *QRinput_splitQRinputToStruct(QRinput *input);
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory.
  */
-extern int QRinput_Struct_insertStructuredAppendHeaders(QRinput_Struct *s);
+QRENCODE_EXTERN int QRinput_Struct_insertStructuredAppendHeaders(QRinput_Struct *s);
 
 /**
  * Set FNC1-1st position flag.
  */
-extern int QRinput_setFNC1First(QRinput *input);
+QRENCODE_EXTERN int QRinput_setFNC1First(QRinput *input);
 
 /**
  * Set FNC1-2nd position flag and application identifier.
  */
-extern int QRinput_setFNC1Second(QRinput *input, unsigned char appid);
+QRENCODE_EXTERN int QRinput_setFNC1Second(QRinput *input, unsigned char appid);
 
 /******************************************************************************
  * QRcode output (qrencode.c)
@@ -398,7 +408,7 @@ typedef struct _QRcode_List {
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory for input objects.
  */
-extern QRcode *QRcode_encodeInput(QRinput *input);
+QRENCODE_EXTERN QRcode *QRcode_encodeInput(QRinput *input);
 
 /**
  * Create a symbol from the string. The library automatically parses the input
@@ -423,25 +433,25 @@ extern QRcode *QRcode_encodeInput(QRinput *input);
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw ERANGE input data is too large.
  */
-extern QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
+QRENCODE_EXTERN QRcode *QRcode_encodeString(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
 
 /**
  * Same to QRcode_encodeString(), but encode whole data in 8-bit mode.
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode *QRcode_encodeString8bit(const char *string, int version, QRecLevel level);
 
 /**
  * Micro QR Code version of QRcode_encodeString().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
+QRENCODE_EXTERN QRcode *QRcode_encodeStringMQR(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
 
 /**
  * Micro QR Code version of QRcode_encodeString8bit().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecLevel level);
 
 /**
  * Encode byte stream (may include '\0') in 8-bit mode.
@@ -455,19 +465,19 @@ extern QRcode *QRcode_encodeString8bitMQR(const char *string, int version, QRecL
  * @throw ENOMEM unable to allocate memory for input objects.
  * @throw ERANGE input data is too large.
  */
-extern QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode *QRcode_encodeData(int size, const unsigned char *data, int version, QRecLevel level);
 
 /**
  * Micro QR Code version of QRcode_encodeData().
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode *QRcode_encodeDataMQR(int size, const unsigned char *data, int version, QRecLevel level);
 
 /**
  * Free the instance of QRcode class.
  * @param qrcode an instance of QRcode class.
  */
-extern void QRcode_free(QRcode *qrcode);
+QRENCODE_EXTERN void QRcode_free(QRcode *qrcode);
 
 /**
  * Create structured symbols from the input data.
@@ -475,7 +485,7 @@ extern void QRcode_free(QRcode *qrcode);
  * @param s input data, structured.
  * @return a singly-linked list of QRcode.
  */
-extern QRcode_List *QRcode_encodeInputStructured(QRinput_Struct *s);
+QRENCODE_EXTERN QRcode_List *QRcode_encodeInputStructured(QRinput_Struct *s);
 
 /**
  * Create structured symbols from the string. The library automatically parses
@@ -496,13 +506,13 @@ extern QRcode_List *QRcode_encodeInputStructured(QRinput_Struct *s);
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory for input objects.
  */
-extern QRcode_List *QRcode_encodeStringStructured(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
+QRENCODE_EXTERN QRcode_List *QRcode_encodeStringStructured(const char *string, int version, QRecLevel level, QRencodeMode hint, int casesensitive);
 
 /**
  * Same to QRcode_encodeStringStructured(), but encode whole data in 8-bit mode.
  * @warning This function is THREAD UNSAFE when pthread is disabled.
  */
-extern QRcode_List *QRcode_encodeString8bitStructured(const char *string, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode_List *QRcode_encodeString8bitStructured(const char *string, int version, QRecLevel level);
 
 /**
  * Create structured symbols from byte stream (may include '\0'). Wholde data
@@ -517,20 +527,20 @@ extern QRcode_List *QRcode_encodeString8bitStructured(const char *string, int ve
  * @throw EINVAL invalid input object.
  * @throw ENOMEM unable to allocate memory for input objects.
  */
-extern QRcode_List *QRcode_encodeDataStructured(int size, const unsigned char *data, int version, QRecLevel level);
+QRENCODE_EXTERN QRcode_List *QRcode_encodeDataStructured(int size, const unsigned char *data, int version, QRecLevel level);
 
 /**
  * Return the number of symbols included in a QRcode_List.
  * @param qrlist a head entry of a QRcode_List.
  * @return number of symbols in the list.
  */
-extern int QRcode_List_size(QRcode_List *qrlist);
+QRENCODE_EXTERN int QRcode_List_size(QRcode_List *qrlist);
 
 /**
  * Free the QRcode_List.
  * @param qrlist a head entry of a QRcode_List.
  */
-extern void QRcode_List_free(QRcode_List *qrlist);
+QRENCODE_EXTERN void QRcode_List_free(QRcode_List *qrlist);
 
 
 /******************************************************************************
@@ -543,22 +553,22 @@ extern void QRcode_List_free(QRcode_List *qrlist);
  * @param minor_version minor version number
  * @param micro_version micro version number
  */
-extern void QRcode_APIVersion(int *major_version, int *minor_version, int *micro_version);
+QRENCODE_EXTERN void QRcode_APIVersion(int *major_version, int *minor_version, int *micro_version);
 
 /**
  * Return a string that identifies the library version.
  * @return a string identifies the library version. The string is held by the
  * library. Do NOT free it.
  */
-extern char *QRcode_APIVersionString(void);
+QRENCODE_EXTERN char *QRcode_APIVersionString(void);
 
 /**
  * @deprecated
  */
 #ifndef _MSC_VER
-extern void QRcode_clearCache(void) __attribute__ ((deprecated));
+QRENCODE_EXTERN void QRcode_clearCache(void) __attribute__ ((deprecated));
 #else
-extern void QRcode_clearCache(void);
+QRENCODE_EXTERN void QRcode_clearCache(void);
 #endif
 
 #if defined(__cplusplus)

--- a/qrencode.h
+++ b/qrencode.h
@@ -110,7 +110,11 @@ extern "C" {
 #define QRENCODE_EXTERN __declspec(dllimport)
 #endif
 #else
+#if defined(__GNUC__)
+#define QRENCODE_EXTERN extern __attribute__((visibility("default")))
+#else
 #define QRENCODE_EXTERN extern
+#endif
 #endif
 
 /**


### PR DESCRIPTION
See https://web.archive.org/web/20140808231508/http://blogs.msdn.com/b/russellk/archive/2005/03/20/399465.aspx for why that's needed.