### PR TITLE
cmake: Refer to `prefix` variable in generated `libqrencode.pc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,9 @@ endif()
 
 include(GNUInstallDirs)
 set(prefix "${CMAKE_INSTALL_PREFIX}")
-set(exec_prefix "${CMAKE_INSTALL_FULL_BINDIR}")
-set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
-set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(exec_prefix "\${prefix}/${CMAKE_INSTALL_BINDIR}")
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 configure_file(qrencode.1.in qrencode.1 @ONLY)


### PR DESCRIPTION
This change:
1. Makes the `libqrencode.pc` files generated by Autotools and CMake more aligned.
2. Allows the `prefix` variable to be redefined if the package is relocated.

For example:
```
$ cmake -B build
$ cmake --build build
$ cmake --install build --prefix /tmp/INSTALL
$ env PKG_CONFIG_PATH=/tmp/INSTALL/lib/pkgconfig pkg-config --cflags --libs libqrencode
-I/usr/local/include -L/usr/local/lib -lqrencode
$ mv /tmp/INSTALL /tmp/foo
$ env PKG_CONFIG_PATH=/tmp/foo/lib/pkgconfig pkg-config --define-variable=prefix=/tmp/foo --libs --cflags libqrencode 
-I/tmp/foo/include -L/tmp/foo/lib -lqrencode
```